### PR TITLE
memory errors on latest 5 version of es

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: elasticsearch
+    image: elasticsearch:2
     ports:
       - 9201:9200
   db:


### PR DESCRIPTION
Elasticsearch with default latest flag installs version 5 and there are issues while starting the service. The earlier version works on most hosts.